### PR TITLE
Feature: Add hero spawn point support

### DIFF
--- a/server/src/maps/hood01.json
+++ b/server/src/maps/hood01.json
@@ -3,18 +3,19 @@
         "width": 3840,
         "height": 2160
     },
+    "maximumTeamSize": 2,
     "teams": {
-        "humans": {
+        "Human": {
             "spawnPoints": [
                 {
-                    "id": "player_01",
+                    "id": "hero_01",
                     "position": {
                         "x": 3140,
                         "y": 600
                     }
                 },
                 {
-                    "id": "player_02",
+                    "id": "hero_02",
                     "position": {
                         "x": 3140,
                         "y": 1560
@@ -22,17 +23,17 @@
                 }
             ]
         },
-        "zombies": {
+        "Zombie": {
             "spawnPoints": [
                 {
-                    "id": "player_01",
+                    "id": "hero_01",
                     "position": {
                         "x": 700,
                         "y": 600
                     }
                 },
                 {
-                    "id": "player_02",
+                    "id": "hero_02",
                     "position": {
                         "x": 700,
                         "y": 1560

--- a/server/src/models/Hero.ts
+++ b/server/src/models/Hero.ts
@@ -10,16 +10,19 @@ export class Hero {
     team: Team = 'Human'
     attackedAt?: number = null
     diedAt?: number = null
+    spawnPoint: SpawnPoint
 
-    constructor(team: Team) {
+    constructor(team: Team, spawnPoint: SpawnPoint) {
         this.team = team
+        this.spawnPoint = spawnPoint
+        this.position.x = spawnPoint.position.x
+        this.position.y = spawnPoint.position.y
         this.respawn()
     }
 
     respawn() {
-        // TODO: Spawn near your team's base instead
-        this.position.x = Math.floor(Math.random() * 400)
-        this.position.y = Math.floor(Math.random() * 400)
+        this.position.x = this.spawnPoint.position.x
+        this.position.y = this.spawnPoint.position.y
         this.activity = 'Standing'
         this.hp = 100
         this.facingDirection = this.team === 'Human' ? 'Left' : 'Right'

--- a/types/GameMap.d.ts
+++ b/types/GameMap.d.ts
@@ -9,11 +9,11 @@ interface SpawnPoint {
 interface GameTeam {
     spawnPoints: SpawnPoint[]
 }
-
 interface GameMap {
     size: {
         width: number
         height: number
     }
+    maximumTeamSize: number
     teams: { [id: string]: GameTeam }
 }


### PR DESCRIPTION
- assigns a hero a spawn point at creation
- limits team sizes based on map data
- updates team assignment based on current team size
- starts heroes at their assigned spawn point
- returns heroes to their spawn point on respawn