### PR TITLE
Feature: Add map data backing for bases

### DIFF
--- a/client/src/states/level.ts
+++ b/client/src/states/level.ts
@@ -86,15 +86,6 @@ export default class Level extends AppState {
 
             const map = change.value as GameMap
             this.game.world.setBounds(0, 0, map.size.width, map.size.height)
-
-            // Load bases
-            // TODO: load base information (id, position) from map
-            var i: number
-            for (i = 0; i < 2; i++) {
-                const sprite = new BaseSprite(this.game, i * 800 + 800, 400, 1000)
-                this.baseSprites[i] = sprite
-                this.game.add.existing(sprite)
-            }
         })
 
         connection.listen('heroes/:id/attackedAt', (change: Colyseus.DataChange) => {
@@ -186,6 +177,29 @@ export default class Level extends AppState {
                     if (sprite) {
                         sprite.destroy()
                         delete this.heroSprites[change.path.id]
+                    }
+                    break
+                }
+            }
+        })
+
+        connection.listen('bases/:id', (change: Colyseus.DataChange) => {
+            switch (change.operation) {
+                case 'add': {
+                    console.info(`Listen.bases<${change.path.id}> Added`)
+                    const base: Base = change.value
+                    const sprite = new BaseSprite(this.game, base.position.x, base.position.y, base.hp)
+                    this.baseSprites[base.id] = sprite
+                    this.game.add.existing(sprite)
+                    break
+                }
+                case 'remove': {
+                    console.info(`Listen.bases<${change.path.id}> Removed`)
+                    const base: Base = change.value
+                    const sprite = this.baseSprites[base.id]
+                    if (sprite) {
+                        sprite.destroy
+                        delete this.baseSprites[base.id]
                     }
                     break
                 }

--- a/server/src/maps/hood01.json
+++ b/server/src/maps/hood01.json
@@ -23,6 +23,7 @@
                 }
             ],
             "base": {
+                "id": "human_base",
                 "position": {
                     "x": 3540,
                     "y": 1080
@@ -63,6 +64,7 @@
                 }
             ],
             "base": {
+                "id": "zombie_base",
                 "position": {
                     "x": 300,
                     "y": 1080

--- a/server/src/models/Base.ts
+++ b/server/src/models/Base.ts
@@ -1,0 +1,19 @@
+export class Base implements MapPositionable {
+    public static readonly RADIUS: number = 120
+
+    id: string
+    position = {
+        x: 0,
+        y: 0,
+    }
+
+    hp: number = 500
+    team: Team = 'Human'
+
+    constructor(team: Team, mapBase: MapBase) {
+        this.team = team
+        this.id = mapBase.id
+        this.position.x = mapBase.position.x
+        this.position.y = mapBase.position.y
+    }
+}

--- a/server/src/models/GameState.ts
+++ b/server/src/models/GameState.ts
@@ -2,16 +2,16 @@ import { EntityMap, nosync } from 'colyseus'
 
 import { Constants } from '../config'
 import { Hood01 } from '../maps'
-import { Hero } from './Hero'
 import { TimeOfDay } from './TimeOfDay'
+import { Base } from './Base'
+import { Hero } from './Hero'
 import { House } from './House'
-import { open } from 'fs'
-import { connect } from 'tls';
 
 export class GameState {
     map = Hood01
     heroes: EntityMap<Hero> = {}
     houses: EntityMap<House> = {}
+    bases: EntityMap<Base> = {}
 
     timeOfDay: TimeOfDay = new TimeOfDay()
 
@@ -19,8 +19,11 @@ export class GameState {
     @nosync zombieHeroCount = 0
 
     constructor() {
-        this.createHousesForTeam('Human')
-        this.createHousesForTeam('Zombie')
+        const teams: Team[] = ['Human', 'Zombie']
+        for (const team of teams) {
+            this.createBaseForTeam(team)
+            this.createHousesForTeam(team)
+        }
     }
 
     get totalHeroCount() {
@@ -66,6 +69,11 @@ export class GameState {
         } else {
             console.error(`Map is missing enough spawn points for defined team size (${this.map.maximumTeamSize}.`)
         }
+    }
+
+    private createBaseForTeam(team: Team) {
+        const mapBase = this.map.teams[team].base
+        this.bases[mapBase.id] = new Base(team, mapBase)
     }
 
     private createHousesForTeam(team: Team) {
@@ -120,8 +128,7 @@ export class GameState {
     }
 
     attackWithHero(id: string) {
-
-        console.log("Attack! " + id)
+        console.log('Attack! ' + id)
         const now = Date.now()
         var hero = this.heroes[id]
 
@@ -172,7 +179,7 @@ export class GameState {
 
         for (const houseId of Object.keys(this.houses)) {
             const opponentHouse = this.houses[houseId]
-            console.log("Checking house for attack: " + opponentHouse)
+            console.log('Checking house for attack: ' + opponentHouse)
             if (opponentHouse.hp <= 0) {
                 continue
             }
@@ -190,7 +197,7 @@ export class GameState {
                 continue
             }
 
-            console.log("Attacking house")
+            console.log('Attacking house')
             opponentHouse.hp = Math.max(0, opponentHouse.hp - 25)
         }
     }

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,5 +1,7 @@
-import { Hero } from './Hero'
-import { TimeOfDay } from './TimeOfDay'
 import { GameState } from './GameState'
+import { TimeOfDay } from './TimeOfDay'
+import { Hero } from './Hero'
+import { House } from './House'
+import { Base } from './Base'
 
 export { Hero, TimeOfDay, GameState }

--- a/types/GameMap.d.ts
+++ b/types/GameMap.d.ts
@@ -9,7 +9,9 @@ interface MapSpawnPoint extends MapPositionable {
     id: string
 }
 
-interface MapBase extends MapPositionable {}
+interface MapBase extends MapPositionable {
+    id: string
+}
 
 interface MapHouse extends MapPositionable {
     id: string

--- a/types/entities.d.ts
+++ b/types/entities.d.ts
@@ -26,7 +26,7 @@ interface Hero {
     diedAt?: Date
 }
 
-interface House {
+interface TeamEntity {
     id: string
     position: {
         x: number
@@ -35,3 +35,7 @@ interface House {
     hp: number
     team: Team
 }
+
+interface House extends TeamEntity {}
+
+interface Base extends TeamEntity {}


### PR DESCRIPTION
- adds a listener for base data add/remove changes
- creates bases for teams on `GameState` init
- makes `Base ` `MapPositionable`
- updates `Base` constructor to take a `MapBase`
- updates `GameMap` type definitions