### PR TITLE
Fix fog sprite not appearing except in the first game joined

### DIFF
--- a/client/src/states/level.ts
+++ b/client/src/states/level.ts
@@ -64,6 +64,9 @@ export default class Level extends AppState {
     }
 
     create() {
+        this._fogSprite = null
+        this.lastArrowMotion = null
+
         this.app().pauseSong()
 
         const anyWindow = window as any


### PR DESCRIPTION
The Level state lazily loaded resources but didn't reset them between games.

Closes #81.