### PR TITLE
Bugfix: 95 building should not spawn minions after being destroyed

### DIFF
--- a/server/src/maps/hood01.json
+++ b/server/src/maps/hood01.json
@@ -4,6 +4,7 @@
         "height": 2160
     },
     "maximumTeamSize": 2,
+    "maximumTeamMinions": 15,
     "teams": {
         "Human": {
             "spawnPoints": [

--- a/server/src/models/Base.ts
+++ b/server/src/models/Base.ts
@@ -9,6 +9,7 @@ export class Base implements MapPositionable {
         y: 0,
     }
 
+    maximumHP: number = 1500
     hp: number = 1500
     team: Team = 'Human'
     spawnedFoodAt?: number = null

--- a/server/src/models/House.ts
+++ b/server/src/models/House.ts
@@ -9,6 +9,7 @@ export class House implements MapPositionable {
         y: 0,
     }
 
+    maximumHP: number = 500
     hp: number = 500
     team: Team = 'Human'
     minionSpawner: MinionSpawner

--- a/server/src/models/MinionSpawner.ts
+++ b/server/src/models/MinionSpawner.ts
@@ -1,7 +1,7 @@
 import { Minion } from './Minion'
 
 export class MinionSpawner {
-    spawnIntervalInMilliseconds: number = 5000
+    spawnIntervalInMilliseconds: number = 10000
     lastSpawn?: number
     position = {
         x: 0,
@@ -15,7 +15,7 @@ export class MinionSpawner {
         this.position.y = spawnPoint.position.y
     }
 
-    spawnNewMinion() {
+    spawnNewMinion(): Minion {
         this.lastSpawn = Date.now()
         return new Minion(this.team, this.position.x, this.position.y)
     }

--- a/types/GameMap.d.ts
+++ b/types/GameMap.d.ts
@@ -30,5 +30,6 @@ interface GameMap {
         height: number
     }
     maximumTeamSize: number
+    maximumTeamMinions: number
     teams: { [id: string]: MapTeam }
 }


### PR DESCRIPTION
Closes #95 

- adds maximumHP to bases and houses
- adds maximumTeamMinions to GameMap
- adds helper function for checking minion spawn conditions for a team
- adds hp check to minion spawn to prevent spawning at destroyed buildings
- adds team minion counters to avoid unbalanced team defenses
- updates calculation for minion spawn delay based on building hp
- resolves crash when attempting to move food that is `undefined`